### PR TITLE
Fix such that I can add this project as a dependency for other projects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ name = "Filtration_Curves"
 version = "0.1.0"
 description = ""
 authors = ["Leslie O'Bray <leslie.obray@bsse.ethz.ch>"]
+packages = [
+    { include = "src", from="." },
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
Hi! 

I would like to add this package as a dependency of a package I'm working on. I'm using pip and conda to manage my dependencies. My package contains both Python and R code, so poetry isn't an option right now.

In order to install `filtration_curves` using `pip install git+https://github.com/BorgwardtLab/filtration_curves.git`, I had to make a slight modification to `pyproject.toml`, otherwise the installation would fail:

```
error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [16 lines of output]
      Traceback (most recent call last):
        File "/dss/dsshome1/06/di93vel/.conda/envs/test_venv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/dss/dsshome1/06/di93vel/.conda/envs/test_venv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/dss/dsshome1/06/di93vel/.conda/envs/test_venv/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
        File "/gpfs/scratch/pn36po/di93vel/di93vel/pip-build-env-qt3r7vua/overlay/lib/python3.9/site-packages/poetry/core/masonry/api.py", line 42, in prepare_metadata_for_build_wheel
          builder = WheelBuilder(poetry)
        File "/gpfs/scratch/pn36po/di93vel/di93vel/pip-build-env-qt3r7vua/overlay/lib/python3.9/site-packages/poetry/core/masonry/builders/wheel.py", line 62, in __init__
          super().__init__(poetry, executable=executable)
        File "/gpfs/scratch/pn36po/di93vel/di93vel/pip-build-env-qt3r7vua/overlay/lib/python3.9/site-packages/poetry/core/masonry/builders/builder.py", line 85, in __init__
          self._module = Module(
        File "/gpfs/scratch/pn36po/di93vel/di93vel/pip-build-env-qt3r7vua/overlay/lib/python3.9/site-packages/poetry/core/masonry/utils/module.py", line 69, in __init__
          raise ModuleOrPackageNotFound(
      poetry.core.masonry.utils.module.ModuleOrPackageNotFound: No file/folder found for package filtration-curves
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```

I remain able to install the package using poetry with or without this modification.